### PR TITLE
Add user-friendly FastAPI Hot Wheels manager

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,150 +2,184 @@ from fastapi import FastAPI, Request, Form, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
+from typing import List, Dict
 import csv
 import os
 import io
 import re
-from typing import Dict, List
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+BASE_DIR = os.path.dirname(__file__)
+DATA_DIR = os.path.join(BASE_DIR, 'data')
 COLLECTION_FILE = os.path.join(DATA_DIR, 'HotWheelsGitCollection.csv')
 MASTER_FILE = os.path.join(DATA_DIR, 'DONE_HotWheels1_commas.csv')
-
 REQUIRED_FIELDS = ["toy_number", "name", "year", "series", "image_url", "quantity"]
 
-templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), 'templates'))
-app = FastAPI()
+app = FastAPI(title="Hot Wheels Collection")
+templates = Jinja2Templates(directory=os.path.join(BASE_DIR, 'templates'))
+app.mount('/static', StaticFiles(directory=os.path.join(BASE_DIR, 'static')), name='static')
+
+SERIES_CLEAN_RE = re.compile(r"(New for \d{4}|2nd Color|Exclusive)", re.IGNORECASE)
+
+
+def normalize_series(series: str) -> str:
+    """Remove special tags from series string."""
+    return SERIES_CLEAN_RE.sub('', series).strip()
+
 
 class CSVCache:
+    """Simple cache that reloads CSV when the file changes."""
+
     def __init__(self, path: str):
         self.path = path
-        self.mtime = None
+        self.mtime: float | None = None
         self.data: List[Dict[str, str]] = []
+        self.ensure_file()
+
+    def ensure_file(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        if not os.path.exists(self.path):
+            with open(self.path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=REQUIRED_FIELDS)
+                writer.writeheader()
+            self.mtime = os.path.getmtime(self.path)
 
     def load(self) -> List[Dict[str, str]]:
-        try:
-            stat = os.stat(self.path)
-        except FileNotFoundError:
-            raise HTTPException(status_code=500, detail=f"File not found: {self.path}")
+        self.ensure_file()
+        stat = os.stat(self.path)
         if self.mtime != stat.st_mtime:
             with open(self.path, newline='', encoding='utf-8') as f:
                 reader = csv.DictReader(f)
-                headers = reader.fieldnames
-                if headers is None or any(h not in REQUIRED_FIELDS for h in headers):
-                    raise HTTPException(status_code=500, detail="Invalid CSV headers")
-                self.data = []
-                for row in reader:
-                    cleaned = {k: row.get(k, '').strip() for k in REQUIRED_FIELDS}
-                    if not cleaned['quantity']:
-                        cleaned['quantity'] = '0'
-                    self.data.append(cleaned)
+                if reader.fieldnames != REQUIRED_FIELDS:
+                    # auto-fix invalid headers
+                    rows = [row for row in reader]
+                    self.save(rows)
+                else:
+                    self.data = [{k: row.get(k, '').strip() for k in REQUIRED_FIELDS} for row in reader]
             self.mtime = stat.st_mtime
         return self.data
 
-    def save(self, rows: List[Dict[str, str]]):
+    def save(self, rows: List[Dict[str, str]]) -> None:
+        self.ensure_file()
         with open(self.path, 'w', newline='', encoding='utf-8') as f:
             writer = csv.DictWriter(f, fieldnames=REQUIRED_FIELDS)
             writer.writeheader()
             for row in rows:
                 writer.writerow(row)
-        self.mtime = os.stat(self.path).st_mtime
+        self.mtime = os.path.getmtime(self.path)
         self.data = rows
+
 
 collection_cache = CSVCache(COLLECTION_FILE)
 master_cache = CSVCache(MASTER_FILE)
 
-SERIES_CLEAN_RE = re.compile(r"(New for \d{4}|2nd Color|Exclusive)", re.IGNORECASE)
 
-def normalize_series(series: str) -> str:
-    return SERIES_CLEAN_RE.sub('', series).strip()
+# ---------------------- helper functions ----------------------
 
-# Utility functions
-
-def find_in_master(toy_number: str) -> Dict[str, str]:
+def find_in_master(toy_number: str) -> Dict[str, str] | None:
+    toy_number = toy_number.upper().strip()
     for row in master_cache.load():
-        if row['toy_number'].upper() == toy_number.upper():
+        if row['toy_number'].upper() == toy_number:
             return row
-    return {}
+    return None
 
 
 def add_or_update_model(toy_number: str, quantity: int) -> Dict[str, str]:
+    if quantity < 1:
+        raise HTTPException(status_code=400, detail="Quantity must be positive")
     master_row = find_in_master(toy_number)
     if not master_row:
         raise HTTPException(status_code=400, detail="Invalid toy_number")
+
     rows = collection_cache.load()
     for row in rows:
         if row['toy_number'] == master_row['toy_number'] and row['image_url'] == master_row['image_url']:
-            q = int(row.get('quantity', '1')) + quantity
-            row['quantity'] = str(max(q, 1))
+            new_q = max(int(row.get('quantity', '1')) + quantity, 1)
+            row['quantity'] = str(new_q)
             collection_cache.save(rows)
             return row
-    new_row = {
-        'toy_number': master_row['toy_number'],
-        'name': master_row['name'],
-        'year': master_row['year'],
-        'series': master_row['series'],
-        'image_url': master_row['image_url'],
-        'quantity': str(max(quantity, 1)),
-    }
+
+    new_row = {k: master_row[k] for k in REQUIRED_FIELDS[:-1]}
+    new_row['quantity'] = str(quantity)
     rows.append(new_row)
     collection_cache.save(rows)
     return new_row
 
+
+def parse_bulk(text: str) -> List[tuple[str, int]]:
+    pattern = re.compile(r'(?:x?(\d+)\s*)?([A-Za-z0-9]+)')
+    return [(toy.upper(), int(qty) if qty else 1) for qty, toy in pattern.findall(text)]
+
+
+def progress_map() -> Dict[str, Dict[str, int]]:
+    master = master_cache.load()
+    collection = collection_cache.load()
+    prog: Dict[str, Dict[str, int]] = {}
+    for row in master:
+        key = f"{normalize_series(row['series'])} {row['year']}"
+        prog.setdefault(key, {'total': 0, 'owned': 0})
+        prog[key]['total'] += 1
+    for row in collection:
+        key = f"{normalize_series(row['series'])} {row['year']}"
+        if key in prog:
+            prog[key]['owned'] += 1
+    return prog
+
+
+# --------------------------- routes ---------------------------
+
 @app.get('/form', response_class=HTMLResponse)
 async def form(request: Request):
-    return templates.TemplateResponse('form.html', {'request': request})
+    """Main entry page with forms to add models."""
+    return templates.TemplateResponse('form.html', {'request': request, 'title': 'Add Model'})
+
 
 @app.post('/collect_form')
 async def collect_form(toy_number: str = Form(...), quantity: int = Form(1)):
     try:
         row = add_or_update_model(toy_number, quantity)
+        return {'status': 'ok', 'added': row}
     except HTTPException as e:
         return JSONResponse({'status': 'error', 'reason': e.detail})
-    return {'status': 'ok', 'added': row}
+
 
 @app.post('/collect_bulk')
 async def collect_bulk(text: str = Form(...)):
-    entries = re.findall(r'(?:x?(\d+)\s*)?([A-Za-z0-9]+)', text)
+    entries = parse_bulk(text)
     if not entries:
-        return {'status': 'error', 'reason': 'No entries found'}
-    results = []
-    for qty, toy in entries:
-        q = int(qty) if qty else 1
+        return {'status': 'error', 'reason': 'No valid entries found'}
+    added = []
+    for toy, qty in entries:
         try:
-            row = add_or_update_model(toy, q)
-            results.append(row)
+            row = add_or_update_model(toy, qty)
+            added.append(row)
         except HTTPException:
             continue
-    return {'status': 'ok', 'added': results}
+    return {'status': 'ok', 'added': added}
+
 
 @app.get('/collection', response_class=HTMLResponse)
-async def show_collection(request: Request):
+async def show_collection(request: Request, q: str | None = None):
     rows = collection_cache.load()
-    return templates.TemplateResponse('collection.html', {'request': request, 'rows': rows})
+    if q:
+        q_low = q.lower()
+        rows = [r for r in rows if q_low in r['toy_number'].lower() or q_low in r['name'].lower()]
+    total = sum(int(r['quantity']) for r in rows)
+    context = {'request': request, 'rows': rows, 'total': total, 'q': q}
+    return templates.TemplateResponse('collection.html', context)
 
-@app.get('/lost')
-async def lost():
-    master = master_cache.load()
-    collection = collection_cache.load()
-    coll_set = set(row['toy_number'] for row in collection)
-    missing = [row for row in master if row['toy_number'] not in coll_set]
-    return {'status': 'ok', 'missing': missing}
 
-@app.get('/compare')
-async def compare():
+@app.get('/lost', response_class=HTMLResponse)
+async def lost(request: Request):
     master = master_cache.load()
-    collection = collection_cache.load()
-    series_map: Dict[str, Dict[str, int]] = {}
-    for row in master:
-        key = f"{normalize_series(row['series'])} {row['year']}"
-        series_map.setdefault(key, {'total': 0, 'owned': 0})
-        series_map[key]['total'] += 1
-    for row in collection:
-        key = f"{normalize_series(row['series'])} {row['year']}"
-        if key in series_map:
-            series_map[key]['owned'] += 1
-    return {'status': 'ok', 'progress': series_map}
+    collection = {row['toy_number'] for row in collection_cache.load()}
+    missing = [row for row in master if row['toy_number'] not in collection]
+    return templates.TemplateResponse('lost.html', {'request': request, 'rows': missing})
+
+
+@app.get('/compare', response_class=HTMLResponse)
+async def compare(request: Request):
+    return templates.TemplateResponse('compare.html', {'request': request, 'progress': progress_map()})
+
 
 @app.get('/toy_info')
 async def toy_info(toy_number: str):
@@ -154,16 +188,18 @@ async def toy_info(toy_number: str):
         return {'status': 'error', 'reason': 'Not found'}
     return {'status': 'ok', 'info': row}
 
+
 @app.post('/adjust_quantity')
 async def adjust_quantity(toy_number: str = Form(...), delta: int = Form(...)):
     rows = collection_cache.load()
     for row in rows:
         if row['toy_number'] == toy_number:
-            q = max(int(row['quantity']) + delta, 1)
-            row['quantity'] = str(q)
+            new_q = max(int(row['quantity']) + delta, 1)
+            row['quantity'] = str(new_q)
             collection_cache.save(rows)
-            return {'status': 'ok', 'new_quantity': q}
+            return {'status': 'ok', 'new_quantity': new_q}
     return {'status': 'error', 'reason': 'Model not found'}
+
 
 @app.post('/delete_model')
 async def delete_model(toy_number: str = Form(...)):
@@ -173,6 +209,7 @@ async def delete_model(toy_number: str = Form(...)):
         return {'status': 'error', 'reason': 'Model not found'}
     collection_cache.save(new_rows)
     return {'status': 'ok'}
+
 
 @app.get('/download_csv')
 async def download_csv():
@@ -184,6 +221,30 @@ async def download_csv():
         writer.writerow(row)
     return StreamingResponse(iter([output.getvalue()]), media_type='text/csv', headers={'Content-Disposition': 'attachment; filename=collection.csv'})
 
+
 @app.get('/json')
 async def get_json():
     return collection_cache.load()
+
+
+# -------------------- admin/cache endpoints --------------------
+
+@app.post('/admin/reload')
+async def admin_reload(file: str = Form(...)):
+    if file == 'master':
+        master_cache.mtime = None
+        master_cache.load()
+    elif file == 'collection':
+        collection_cache.mtime = None
+        collection_cache.load()
+    else:
+        raise HTTPException(status_code=400, detail='unknown file')
+    return {'status': 'ok'}
+
+
+@app.get('/admin/cache_status')
+async def cache_status():
+    return {
+        'collection_mtime': collection_cache.mtime,
+        'master_mtime': master_cache.mtime,
+    }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title or 'Hot Wheels Collection' }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container my-4">
+<nav class="mb-4">
+    <a href="/form" class="btn btn-primary me-2">Add</a>
+    <a href="/collection" class="btn btn-secondary me-2">Collection</a>
+    <a href="/compare" class="btn btn-info me-2">Progress</a>
+    <a href="/lost" class="btn btn-warning">Missing</a>
+</nav>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/collection.html
+++ b/app/templates/collection.html
@@ -1,20 +1,45 @@
-<!DOCTYPE html>
-<html>
-<head><title>Collection</title></head>
-<body>
+{% extends 'base.html' %}
+{% block content %}
 <h1>My Collection</h1>
-<table border="1">
-<tr><th>Toy Number</th><th>Name</th><th>Year</th><th>Series</th><th>Image</th><th>Quantity</th></tr>
-{% for row in rows %}
-<tr>
-<td>{{ row.toy_number }}</td>
-<td>{{ row.name }}</td>
-<td>{{ row.year }}</td>
-<td>{{ row.series }}</td>
-<td><img src="{{ row.image_url }}" width="50"/></td>
-<td>{{ row.quantity }}</td>
-</tr>
-{% endfor %}
+<form method="get" class="mb-3">
+  <input class="form-control" type="text" name="q" placeholder="Search" value="{{ q or '' }}">
+</form>
+<p>Total Models: {{ total }}</p>
+<table class="table table-striped table-sm">
+  <thead>
+    <tr>
+      <th>Toy</th><th>Name</th><th>Year</th><th>Series</th><th>Image</th><th>Qty</th><th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>{{ row.toy_number }}</td>
+      <td>{{ row.name }}</td>
+      <td>{{ row.year }}</td>
+      <td>{{ row.series }}</td>
+      <td><img src="{{ row.image_url }}" width="50"></td>
+      <td>{{ row.quantity }}</td>
+      <td>
+        <form action="/adjust_quantity" method="post" class="d-inline">
+          <input type="hidden" name="toy_number" value="{{ row.toy_number }}">
+          <input type="hidden" name="delta" value="-1">
+          <button class="btn btn-sm btn-outline-secondary">-</button>
+        </form>
+        <form action="/adjust_quantity" method="post" class="d-inline">
+          <input type="hidden" name="toy_number" value="{{ row.toy_number }}">
+          <input type="hidden" name="delta" value="1">
+          <button class="btn btn-sm btn-outline-secondary">+</button>
+        </form>
+        <form action="/delete_model" method="post" class="d-inline" onsubmit="return confirm('Delete?');">
+          <input type="hidden" name="toy_number" value="{{ row.toy_number }}">
+          <button class="btn btn-sm btn-outline-danger">X</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>
-</body>
-</html>
+<a href="/download_csv" class="btn btn-secondary">Download CSV</a>
+<a href="/json" class="btn btn-secondary">Download JSON</a>
+{% endblock %}

--- a/app/templates/compare.html
+++ b/app/templates/compare.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Progress</h1>
+<table class="table table-sm">
+<thead><tr><th>Series/Year</th><th>Progress</th></tr></thead>
+<tbody>
+{% for key, v in progress.items() %}
+<tr>
+  <td>{{ key }}</td>
+  <td>
+    <div class="progress">
+      <div class="progress-bar" role="progressbar" style="width: {{ (v.owned / v.total * 100) | round(1) }}%" aria-valuenow="{{ v.owned }}" aria-valuemin="0" aria-valuemax="{{ v.total }}">{{ v.owned }}/{{ v.total }}</div>
+    </div>
+  </td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,19 +1,22 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Hot Wheels Collection</title>
-</head>
-<body>
+{% extends 'base.html' %}
+{% block content %}
 <h1>Add Model</h1>
-<form action="/collect_form" method="post">
-    Toy Number: <input type="text" name="toy_number" />
-    Quantity: <input type="number" name="quantity" value="1" />
-    <button type="submit">Add</button>
+<form action="/collect_form" method="post" class="mb-3">
+  <div class="mb-2">
+    <label class="form-label">Toy Number</label>
+    <input class="form-control" name="toy_number" required>
+  </div>
+  <div class="mb-2">
+    <label class="form-label">Quantity</label>
+    <input class="form-control" type="number" name="quantity" value="1" min="1">
+  </div>
+  <button class="btn btn-success">Add</button>
 </form>
 <h2>Bulk Add</h2>
 <form action="/collect_bulk" method="post">
-    <textarea name="text" rows="5" cols="40"></textarea>
-    <button type="submit">Import</button>
+  <div class="mb-2">
+    <textarea name="text" rows="5" class="form-control" placeholder="2x HYW18, HYW19, x3 HTD77"></textarea>
+  </div>
+  <button class="btn btn-success">Import</button>
 </form>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/lost.html
+++ b/app/templates/lost.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Missing Models</h1>
+<table class="table table-striped table-sm">
+  <thead><tr><th>Toy</th><th>Name</th><th>Year</th><th>Series</th></tr></thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>{{ row.toy_number }}</td>
+      <td>{{ row.name }}</td>
+      <td>{{ row.year }}</td>
+      <td>{{ row.series }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Bootstrap-based HTML templates
- implement caching CSV handler and progress computation
- refactor main FastAPI app with all required endpoints
- adjust requirements

## Testing
- `pip install -q -r requirements.txt`
- `python - <<'EOF'
import app.main
print('loaded')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_685155eb7e14832780b163a0f0712355